### PR TITLE
Fixing LoadError for loggable

### DIFF
--- a/lib/beez.rb
+++ b/lib/beez.rb
@@ -1,7 +1,7 @@
 require 'concurrent'
 
 require 'beez/configurable'
-require 'beez/Loggable'
+require 'beez/loggable'
 require 'beez/client'
 require 'beez/worker'
 require 'beez/version'


### PR DESCRIPTION
When running rspec tests in a project using this gem, the runner throws the following error:

```
Failure/Error: require File.expand_path("../config/environment", __dir__)

LoadError:
  cannot load such file -- beez/Loggable
# ./config/application.rb:20:in `<top (required)>'
# ./config/environment.rb:2:in `require_relative'
# ./config/environment.rb:2:in `<top (required)>'
# ./spec/spec_helper.rb:2:in `require'
# ./spec/spec_helper.rb:2:in `<top (required)>'
```

Which is clearly a typo in the require statement.
