### PR TITLE
Add deploy_resource and variables to complete_job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `zeebe-client` gem from `0.10.1` to `0.16.2` to be compatible with Zeebe `>= 1.0.0`
 - Rename `Beez::Client.create_workflow_instance` into `create_process_instance`
 - Rename `Beez::Client.deploy_workflow` into `deploy_process`
+- Added `Beez::Client.deploy_resource` method
+- Use return value of worker's process method to pass variables into complete_job
 
 ### Fixed
 

--- a/lib/beez/client.rb
+++ b/lib/beez/client.rb
@@ -43,6 +43,13 @@ module Beez
       )
     end
 
+    def deploy_resource(params = {})
+      run(
+        :deploy_resource,
+        ::Zeebe::Client::GatewayProtocol::DeployResourceRequest.new(params)
+      )
+    end
+
     def fail_job(params = {})
       run(
         :fail_job,

--- a/lib/beez/processor.rb
+++ b/lib/beez/processor.rb
@@ -53,8 +53,8 @@ module Beez
 
         duration =
           measure_duration do
-            worker.process(job)
-            worker.complete_job(job)
+            variables = worker.process(job)
+            worker.complete_job(job, variables: variables)
           end
 
         logger.info "class=#{worker_class} jid=#{job.key} duration=#{duration} Done processing #{job.type}"


### PR DESCRIPTION
This PR adds a new method for the client to deploy a resource (https://docs.camunda.io/docs/apis-clients/grpc/#deployresource-rpc). The previous `deploy_process` call is now deprecated:
https://docs.camunda.io/docs/apis-clients/grpc/#deployprocess-rpc

Also, there's a small addition to make sure that we can pass along variables when completing a job from the process' return value.

Let me know what you think and if we could get this merged / released. 
Thanks.